### PR TITLE
patch relevant to issue #6

### DIFF
--- a/osnma/osnma_core/receiver_state.py
+++ b/osnma/osnma_core/receiver_state.py
@@ -417,11 +417,17 @@ class ReceiverState:
                 logger.error(f"ERROR: Unable to parse the MACK message correctly.\n{e}")
                 if self.start_status == StartStates.HOT_START:
                     self._fallback_to_warm_start()
+                else:
+                    logger.warning("WARNING: Deleting first mack message from waiting list")
+                    self.kroot_waiting_mack = self.kroot_waiting_mack[1:]
             except TeslaKeyVerificationFailed as e:
                 # Unable to verify the TESLA key
                 logger.error(f"Failed authenticating a TESLA key.\n{e}")
                 if self.start_status == StartStates.HOT_START:
                     self._fallback_to_warm_start()
+                else:
+                    logger.warning("WARNING: Deleting first mack message from waiting list")
+                    self.kroot_waiting_mack = self.kroot_waiting_mack[1:]
             else:
                 if self.start_status == StartStates.HOT_START:
                     self.start_status = StartStates.STARTED


### PR DESCRIPTION
Added custom else clauses in the try-except block of the process_mack_subframe method to remove from self.kroot_waiting_mack list any invalid mack subframes triggering MackParsingError or TeslaKeyVerificationFailed.