### PR TITLE
Implement COP to link ADKD0/12 data and remove old data

### DIFF
--- a/osnma/osnma_core/nav_data_manager.py
+++ b/osnma/osnma_core/nav_data_manager.py
@@ -394,14 +394,6 @@ class NavigationDataManager:
         return nav_data
 
     def add_authenticated_tag(self, tag: TagAndInfo):
-
-        if tag.is_dummy:
-            return
-
-        if tag.adkd.uint == 0:
-            tag.nav_data.last_cop = tag.cop.uint
-            tag.nav_data.last_cop_gst = tag.gst_subframe
-
         if tag.id in self.tags_accumulated:
             self.tags_accumulated[tag.id].add_tag(tag)
         else:

--- a/osnma/osnma_core/receiver_state.py
+++ b/osnma/osnma_core/receiver_state.py
@@ -413,7 +413,6 @@ class ReceiverState:
                         self.tesla_chain_force.parse_mack_message(w_mack[0], w_mack[1], w_mack[2], w_mack[3])
                     self.kroot_waiting_mack = []
                 self.tesla_chain_force.parse_mack_message(mack_subframe, gst_subframe, svid, sf_nma_status)
-                self.tesla_chain_force.update_tag_lists(gst_subframe)
 
             except MackParsingError as e:
                 # Unable to parse the message correctly

--- a/osnma/osnma_core/tag_verification.py
+++ b/osnma/osnma_core/tag_verification.py
@@ -165,8 +165,7 @@ class TagStateStructure:
                     self.tags_awaiting_key.remove(tag)
 
         # Check if any data can be authenticated
-        logger.info(f"Data authenticated:\n")
-        self.nav_data_m.get_authenticated_data(gst_subframe)
+        self.nav_data_m.check_authenticated_data(gst_subframe)
 
     def load_mack_message(self, mack_message: MACKMessage):
         tag_list, macseq, is_flx_tag_missing = self.verify_maclt(mack_message)

--- a/osnma/osnma_core/tag_verification.py
+++ b/osnma/osnma_core/tag_verification.py
@@ -62,7 +62,7 @@ class TagStateStructure:
         if tag.authenticate(self.tesla_chain.mac_function):
             logger.info(f"Tag AUTHENTICATED\n\t{tag.get_log()}")
             if not tag.is_dummy:
-                self.nav_data_m.add_authenticated_tag(tag)
+                self.nav_data_m.new_tag_verified(tag)
         else:
             logger.error(f"Tag FAILED\n\t{tag.get_log()}")
         self.tags_awaiting_key.remove(tag)
@@ -166,7 +166,7 @@ class TagStateStructure:
 
         # Check if any data can be authenticated
         logger.info(f"Data authenticated:\n")
-        self.nav_data_m.authenticated_data(gst_subframe)
+        self.nav_data_m.get_authenticated_data(gst_subframe)
 
     def load_mack_message(self, mack_message: MACKMessage):
         tag_list, macseq, is_flx_tag_missing = self.verify_maclt(mack_message)

--- a/osnma/osnma_core/tesla_chain.py
+++ b/osnma/osnma_core/tesla_chain.py
@@ -15,7 +15,7 @@
 #
 
 ######## type annotations ########
-from typing import Union, List, Optional
+from typing import Union, List
 from osnma.osnma_core.nav_data_manager import NavigationDataManager
 from osnma.structures.mack_structures import MACSeqObject, TagAndInfo
 

--- a/osnma/osnma_core/tesla_chain.py
+++ b/osnma/osnma_core/tesla_chain.py
@@ -167,10 +167,9 @@ class TESLAChain:
         else:
             self.tags_structure.load_mack_message(mack_object)
             if tesla_key := mack_object.get_key():
-                self.add_key(tesla_key)
-
-    def update_tag_lists(self, gst_subframe: GST):
-        self.tags_structure.update_tag_lists(gst_subframe)
+                verified, is_new_key = self.add_key(tesla_key)
+                if verified and is_new_key:
+                    self.tags_structure.update_tag_lists(gst_sf)
 
     def get_key_index(self, gst_sf: GST) -> int:
         """Computes the key index that would have a key received on the subframe specified and in the position specified
@@ -186,22 +185,6 @@ class TESLAChain:
 
         return index
 
-    def get_wn_towh(self) -> (int, int):
-        """Get the WN and TOWH (hours) of Chain applicability. Computed from the continuous GST0 attribute.
-
-        :return: Tuple[WN,TOWH]
-        :rtype: (int, int)
-        """
-        return self.GST0.wn, self.GST0.tow//3600
-
-    def set_cid(self, cid: int):
-        """Set the CID of the TESLA Chain. This value identifies each Chain and rolls over 3.
-
-        :param cid: Chain ID value, from 0 to 3.
-        :type cid: int
-        """
-        self.chain_id = cid
-
     def add_key(self, new_tesla_key: TESLAKey) -> (bool, int):
         """Verifies the new tesla key by computing the necessary hashes until reaching the index of the
         `self.last_tesla_key`. Then compares the key value. If the keys are the same, the key is verified and the
@@ -209,25 +192,23 @@ class TESLAChain:
 
         :param new_tesla_key: TESLA Key to be added to the Chain.
         :type new_tesla_key: TESLAKey
-        :return: Tuple indicating if the key has been verified and its index.
-        :rtype: (bool, int)
+        :return: Tuple indicating if the key has been verified and if it is a new key.
+        :rtype: (bool, bool)
         """
 
         # Calculate the index of the new key
         new_tesla_key.calculate_index(self.GST0)
+        is_new_key = (self.last_tesla_key.index < new_tesla_key.index)
 
-        # Starts with the hashes
+        # Copy the key reference to iterate on it
         new_key_index = new_tesla_key.index
-        last_tesla_key = self.last_tesla_key
         tesla_key = new_tesla_key
+
         key_verified = False
         for key_index in reversed(range(new_key_index + 1)):
-            if key_index > last_tesla_key.index:
-                # Normal case when a new key is received. If its not the first key, it will compute only 1 key
+            if key_index > self.last_tesla_key.index:
                 tesla_key = self._compute_next_key(tesla_key)
-            elif key_index == last_tesla_key.index and tesla_key.key == last_tesla_key.key:
-                new_tesla_key.set_verified(True)
-                self.last_tesla_key = new_tesla_key
+            elif key_index == self.last_tesla_key.index and tesla_key.key == self.last_tesla_key.key:
                 key_verified = True
                 break
             else:
@@ -235,26 +216,17 @@ class TESLAChain:
                 e = TeslaKeyVerificationFailed(f"Tesla Key {new_tesla_key.index} from svid {new_tesla_key.svid}"
                                                  f"{' Reconstructed' if new_tesla_key.reconstructed else ''},"
                                                  f" received at {new_tesla_key.gst_sf} failed verification.\n"
-                                                 f"Last authenticated key: {last_tesla_key.index} at {last_tesla_key.gst_sf}.\n"
+                                                 f"Last authenticated key: {self.last_tesla_key.index} "
+                                                 f"at {self.last_tesla_key.gst_sf}.\n"
                                                  f"Last hash: {key_index} {tesla_key.key}")
-
                 logger.critical(e)
-                exit()
 
         if key_verified:
+            new_tesla_key.set_verified(True)
+            self.last_tesla_key = new_tesla_key
             logger.info(f"Tesla Key Authenticated {new_tesla_key.gst_sf}{' - Regenerated' if new_tesla_key.reconstructed else ''}\n")
 
-        return key_verified, new_key_index
-
-    def _update_tags_key(self, tesla_key: TESLAKey, index: int):
-
-        for macseq_tag in self.tags_structure.macseq_awaiting_key:
-            if not macseq_tag.has_key and macseq_tag.key_id == index:
-                macseq_tag.tesla_key = tesla_key
-
-        for tag in self.tags_structure.tags_awaiting_key:
-            if not tag.has_key and tag.key_id == index:
-                tag.tesla_key = tesla_key
+        return key_verified, is_new_key
 
     def _get_tesla_key(self, wanted_key_index: int) -> TESLAKey:
         """Retrieves a TESLA key according to the index provided. In the strange case that the key solicited is not the

--- a/osnma/structures/mack_structures.py
+++ b/osnma/structures/mack_structures.py
@@ -170,6 +170,10 @@ class TagAndInfo:
     def has_key(self) -> bool:
         return self.tesla_key is not None
 
+    @property
+    def data_id(self):
+        return self.adkd.uint, self.prn_d.uint, self.nav_data.nav_data_stream.tobytes()
+
     def _get_tag_auth_data(self):
         auth_data = self.prn_d + self.prn_a + self.gst_subframe.bitarray + BitArray(uint=self.ctr, length=8) + self.nma_status + self.nav_data.nav_data_stream
         return auth_data

--- a/osnma/structures/mack_structures.py
+++ b/osnma/structures/mack_structures.py
@@ -145,6 +145,7 @@ class TagAndInfo:
         self.key_id: Optional[int] = None
         self.tesla_key: Optional[TESLAKey] = None
         self.is_tag0 = False
+        self.nav_data = None
 
     def __repr__(self) -> str:
         return f"{{ID: ({self.id[0]:02}, {self.id[1]:02}, {self.cop.uint:02}) PRN_A: {self.prn_a.uint:02}}}"

--- a/tests/icd_test_vectors.py
+++ b/tests/icd_test_vectors.py
@@ -58,6 +58,14 @@ def run(input_module, config_dict, expected_results_dict):
         warnings = len(re.findall('WARNING', log_text))
         errors = len(re.findall('ERROR', log_text))
 
+    # print(f'{tags_auth} vs {expected_results_dict["tags_auth"]}')
+    # print(f'{data_auth} vs {expected_results_dict["data_auth"]}')
+    # print(f'{kroot_auth} vs {expected_results_dict["kroot_auth"]}')
+    # print(f'{broken_kroot} vs {expected_results_dict["broken_kroot"]}')
+    # print(f'{crc_failed} vs {expected_results_dict["crc_failed"]}')
+    # print(f'{warnings} vs {expected_results_dict["warnings"]}')
+    # print(f'{errors} vs {expected_results_dict["errors"]}')
+
     assert tags_auth == expected_results_dict["tags_auth"]
     assert data_auth == expected_results_dict["data_auth"]
     assert kroot_auth == expected_results_dict["kroot_auth"]

--- a/tests/icd_test_vectors.py
+++ b/tests/icd_test_vectors.py
@@ -98,7 +98,7 @@ def test_vectors_icd_configuration_2(log_level=logging.INFO):
 
     expected_results = {
         "tags_auth": 11427,
-        "data_auth": 5649,
+        "data_auth": 6056,
         "kroot_auth": 115,
         "broken_kroot": 0,
         "crc_failed": 0,

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -129,7 +129,7 @@ def tow_rollover():
 
 if __name__ == "__main__":
 
-    #test_vectors_icd_configuration_1()
+    # test_vectors_icd_configuration_1()
 
     # test_vectors_icd_configuration_2()
 
@@ -137,7 +137,7 @@ if __name__ == "__main__":
 
     tow_rollover()
 
-    # test_change_of_word_type_5()
+    #test_change_of_word_type_5()
 
     # sbf_new_config()
 

--- a/tests/run_examples.py
+++ b/tests/run_examples.py
@@ -129,13 +129,13 @@ def tow_rollover():
 
 if __name__ == "__main__":
 
-    test_vectors_icd_configuration_1()
+    #test_vectors_icd_configuration_1()
 
     # test_vectors_icd_configuration_2()
 
     # test_vectors_icd_configuration_2_pubk_kroot()
 
-    # tow_rollover()
+    tow_rollover()
 
     # test_change_of_word_type_5()
 

--- a/tests/test_corner_cases.py
+++ b/tests/test_corner_cases.py
@@ -109,8 +109,8 @@ def test_tow_rollover(log_level=logging.INFO):
     }
 
     expected_results = {
-        "tags_auth": 8964,
-        "data_auth": 7399,
+        "tags_auth": 8979,
+        "data_auth": 7404,
         "kroot_auth": 199,
         "broken_kroot": 16,
         "crc_failed": 2498,

--- a/tests/test_corner_cases.py
+++ b/tests/test_corner_cases.py
@@ -58,6 +58,14 @@ def run(input_module, config_dict, expected_results_dict):
         warnings = len(re.findall('WARNING', log_text))
         errors = len(re.findall('ERROR', log_text))
 
+    # print(f'{tags_auth} vs {expected_results_dict["tags_auth"]}')
+    # print(f'{data_auth} vs {expected_results_dict["data_auth"]}')
+    # print(f'{kroot_auth} vs {expected_results_dict["kroot_auth"]}')
+    # print(f'{broken_kroot} vs {expected_results_dict["broken_kroot"]}')
+    # print(f'{crc_failed} vs {expected_results_dict["crc_failed"]}')
+    # print(f'{warnings} vs {expected_results_dict["warnings"]}')
+    # print(f'{errors} vs {expected_results_dict["errors"]}')
+
     assert tags_auth == expected_results_dict["tags_auth"]
     assert data_auth == expected_results_dict["data_auth"]
     assert kroot_auth == expected_results_dict["kroot_auth"]
@@ -102,7 +110,7 @@ def test_tow_rollover(log_level=logging.INFO):
 
     expected_results = {
         "tags_auth": 8964,
-        "data_auth": 7393,
+        "data_auth": 7399,
         "kroot_auth": 199,
         "broken_kroot": 16,
         "crc_failed": 2498,


### PR DESCRIPTION
Use COP to link ADKD0 and ADKD12 data including the IOD link optimization.

Implement a way of cleaning old ADKD0 and ADKD12 data.

Code reorganization for decoupling: tag/macseq stores its data and verifies itself

Future work on reporting authenticated data to be done, remove data authenticator and use data blocks