### PR TITLE
Fix: Ensure complete header reception with MSG_WAITALL flag

### DIFF
--- a/osnma/input_formats/input_sbf.py
+++ b/osnma/input_formats/input_sbf.py
@@ -255,7 +255,7 @@ class SBFLive(PageIterator):
 
         while sync := self.s.recv(2):
             if sync == SYNC:
-                header = sync + self.s.recv(6)
+                header = sync + self.s.recv(6, socket.MSG_WAITALL)
                 crc, block_id, length, block_num, rev_num = parse_header(header)
 
                 if length % 4 != 0:
@@ -314,7 +314,7 @@ class SBFLiveServer(PageIterator):
 
         while sync := self.s.recv(2):
             if sync == SYNC:
-                header = sync + self.s.recv(6)
+                header = sync + self.s.recv(6, socket.MSG_WAITALL)
                 crc, block_id, length, block_num, rev_num = parse_header(header)
 
                 if length % 4 != 0:


### PR DESCRIPTION
## Problem Description
The issue occurs because Python's `recv(bufsize)` method doesn't guarantee receiving the exact number of requested bytes. This leads to incomplete header reading, causing the `length` parameter to be incorrectly calculated.

Specifically, when only part of the 6-byte header is read, the calculated `length` value might be less than 8. This results in a negative value when attempting to read the remaining block with `self.s.recv(length - 8)`, which causes an error since we cannot read a negative number of bytes from a socket buffer.

As explained in correspondence with the library creator, this happens because:
- `recv()` only guarantees reading UP TO the specified number of bytes, not exactly that number
- When the header is incomplete, the `length` field (last 2 bytes of the header) may not be properly read
- This cascades into attempting to read a negative amount of data in subsequent operations

## Solution
I've implemented the solution using the `socket.MSG_WAITALL` flag:
```header = sync + self.s.recv(6, socket.MSG_WAITALL)```

This ensures that the socket operation doesn't return until ALL requested bytes (6 in this case) have been received, preventing incomplete headers and subsequent negative length calculations.